### PR TITLE
Make solutions retain temperature __add__.

### DIFF
--- a/ionize/Solution/__init__.py
+++ b/ionize/Solution/__init__.py
@@ -182,7 +182,7 @@ class Solution(object):
     def __add__(self, other):
         if isinstance(other, Solution):
             ions = list(set(self.ions + other.ions))
-            return Solution(ions, [self.concentration(ion) +
+            new_solution = Solution(ions, [self.concentration(ion) +
                                    other.concentration(ion)
                                    for ion in ions]
                             )
@@ -191,10 +191,14 @@ class Solution(object):
                 ion, concentration = other
                 new_contents = dict(self._contents)
                 new_contents[ion] = self.concentration(ion) + concentration
-                return Solution(new_contents.keys(), new_contents.values())
+                new_solution = Solution(new_contents.keys(), new_contents.values())
             except:
                 raise TypeError('Solutions add to other Solutions or to an'
                                  '(Ion, concentration) iterable pair.')
+        
+        # Update the temperature of the new solution to match this one.
+        new_solution.temperature(self._temperature)
+        return new_solution
 
     __radd__ = __add__
 

--- a/ionize/tests.py
+++ b/ionize/tests.py
@@ -98,7 +98,7 @@ class BaseTestIon(object):
         ref = self.database['tris']
         for name in ['tris', 'bis-tris', 'hydrochloric acid']:
             other = self.database[name]
-            if name is not 'tris':
+            if name != 'tris':
                 self.assertGreater(ref.separability(other, pH=8), 0)
             else:
                 self.assertAlmostEqual(ref.separability(other, pH=8), 0)
@@ -214,7 +214,7 @@ class TestIon(unittest.TestCase):
         ref = self.database['tris']
         for name in ['tris', 'bis-tris', 'hydrochloric acid']:
             other = self.database[name]
-            if name is not 'tris':
+            if name != 'tris':
                 self.assertGreater(ref.separability(other, pH=8), 0)
             else:
                 self.assertAlmostEqual(ref.separability(other, pH=8), 0)
@@ -271,8 +271,13 @@ class TestSolution(unittest.TestCase):
         """Test pH titration."""
         base = Solution(['tris'], [0.1])
         for pH in (1, 3, 5, 7):
-            self.assertAlmostEqual(base.titrate('hydrochloric acid', pH).pH,
-                                   pH)
+            for temperature in (20, 25, 30):
+                base.temperature(temperature)
+                result = base.titrate('hydrochloric acid', pH)
+                # Ensure that the pH search converged.
+                self.assertAlmostEqual(result.pH, pH)
+                # Ensure that we retain the temperature through titration.
+                self.assertEqual(base.temperature(), result.temperature())
 
     def test_solution_titrate(self):
         """Test titration with a solution."""


### PR DESCRIPTION
Solutions were previously reverting to the reference temperature during the addition operation.  

This resulted in titrations only operating at the reference temperature. 

Update makes solutions created by addition retain the temperature of the parent solution. 

(Fixes #79 )