### PR TITLE
Coerce concentrations to vanilla floats.

### DIFF
--- a/ionize/Solution/__init__.py
+++ b/ionize/Solution/__init__.py
@@ -116,7 +116,7 @@ class Solution(object):
             elif concentration <0:
                 raise ValueError('Concentrations must be positive.')
             else:
-                self._contents[ion] = concentration
+                self._contents[ion] = float(concentration)
 
         self._hydronium = database['hydronium']
         self._hydroxide = database['hydroxide']

--- a/ionize/tests.py
+++ b/ionize/tests.py
@@ -342,6 +342,11 @@ class TestSolution(unittest.TestCase):
         self.assertEqual(sol.concentration(sol.ions[0]), 0.1,
                          'Failed to find tris by ion.')
 
+        # Make a separate solution obtained by multiplication
+        sol2 = sol * 2
+        for s in sol, sol2:
+            self.assertEqual(type((s).concentration(sol.ions[0])), float)
+
     def test_getitem(self):
         sol = Solution(['tris', 'hydrochloric acid'],
                        [0.1, 0.05])


### PR DESCRIPTION
Previously Solutions could instantiate with other numeric types, notably numpy floats. This caused undesired inconsistency with operations like right multiplication. 

Concentrations now coerced to floats on instantiation. 

Fixes #77 
